### PR TITLE
feat: add export of filters in dlt-viewer xml format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,11 @@
         "chalk": "^5.3.0",
         "cli-progress": "^3.12.0",
         "commander": "^11.1.0",
+        "filenamify": "^6.0.0",
         "js-yaml": "^4.1.0",
         "json5": "2.2.3",
         "jsonpath": "^1.1.1",
+        "jszip": "^3.10.1",
         "mdast-util-assert": "^5.0.0",
         "mdast-util-to-markdown": "^2.1.0",
         "short-unique-id": "^5.0.3",
@@ -24,7 +26,8 @@
         "unist-util-is": "^6.0.0",
         "unist-util-map": "^4.0.0",
         "unist-util-visit": "^5.0.0",
-        "ws": "^8.14.2"
+        "ws": "^8.14.2",
+        "xmlbuilder2": "^3.1.1"
       },
       "bin": {
         "fba-cli": "dist/index.js"
@@ -1559,6 +1562,50 @@
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^19.0.2"
+      }
+    },
+    "node_modules/@oozcitak/dom": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
+      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/url": "1.0.4",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/infra": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
+      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
+      "dependencies": {
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@oozcitak/url": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
+      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/util": {
+      "version": "8.3.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
+      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -3319,8 +3366,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
@@ -4319,6 +4365,31 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -4837,6 +4908,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4952,8 +5028,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -5126,8 +5201,7 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6140,6 +6214,17 @@
         "node": "*"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6187,6 +6272,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -9894,6 +9987,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10184,8 +10282,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -10539,7 +10636,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -10732,8 +10828,7 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/semantic-release": {
       "version": "22.0.6",
@@ -17587,6 +17682,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -17845,8 +17945,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -17891,7 +17990,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -18511,8 +18609,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -18652,6 +18749,40 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlbuilder2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.1.1.tgz",
+      "integrity": "sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==",
+      "dependencies": {
+        "@oozcitak/dom": "1.15.10",
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8",
+        "js-yaml": "3.14.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "eslint src --ext .ts && tsc",
     "lint": "eslint src --ext .ts",
     "test": "node --experimental-vm-modules node_modules/.bin/jest",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "fba-cli": "npm run build && node dist/index.js"
   },
   "keywords": [
     "fishbone",
@@ -72,9 +73,11 @@
     "chalk": "^5.3.0",
     "cli-progress": "^3.12.0",
     "commander": "^11.1.0",
+    "filenamify": "^6.0.0",
     "js-yaml": "^4.1.0",
     "json5": "2.2.3",
     "jsonpath": "^1.1.1",
+    "jszip": "^3.10.1",
     "mdast-util-assert": "^5.0.0",
     "mdast-util-to-markdown": "^2.1.0",
     "short-unique-id": "^5.0.3",
@@ -84,7 +87,8 @@
     "unist-util-is": "^6.0.0",
     "unist-util-map": "^4.0.0",
     "unist-util-visit": "^5.0.0",
-    "ws": "^8.14.2"
+    "ws": "^8.14.2",
+    "xmlbuilder2": "^3.1.1"
   },
   "devDependencies": {
     "@semantic-release/git": "^10.0.1",

--- a/src/cmdExport.ts
+++ b/src/cmdExport.ts
@@ -1,0 +1,295 @@
+import fs from 'fs'
+
+import chalk from 'chalk'
+import filenamify from 'filenamify'
+import { default as JSON5 } from 'json5'
+import JSZip from 'jszip'
+import { fragment, convert, create } from 'xmlbuilder2'
+
+import { FBEffect, Fishbone, getFBDataFromText, rqUriDecode } from './fbaFormat.js'
+import { XMLBuilder } from 'xmlbuilder2/lib/interfaces.js'
+import { version } from './util.js'
+import { finished } from 'node:stream/promises'
+
+const error = chalk.bold.red
+const warning = chalk.bold.yellow
+const green = chalk.bold.green
+
+export const cmdExport = async (fbaFilePath: string, zipFilePath: string, options: any) => {
+  const { format } = options
+  console.log(`export format '${format}' from '${fbaFilePath}' to '${zipFilePath}''`)
+  switch (format.toLowerCase()) {
+    case 'dlt-viewer':
+      {
+        await openFbaFile(fbaFilePath)
+          .then(async (fba) => {
+            // create the output zip file:
+            const zipFile = new JSZip()
+            exportToDltViewer(fba, zipFile)
+            /*zipFile.filter((path, file) => {
+              console.log(`zipFile: path='${path}'`)
+              return false
+            })*/
+            const ws = fs.createWriteStream(zipFilePath)
+
+            zipFile
+              .generateNodeStream({ type: 'nodebuffer', streamFiles: false, compression: 'DEFLATE' })
+              .pipe(ws)
+              .on('finish', () => {
+                // console.log(green(`successfully wrote '${zipFilePath}'`))
+              })
+
+            await finished(ws).then(
+              () => {
+                console.log(green(`successfully finished writing '${zipFilePath}'`))
+              },
+              (err) => {
+                console.log(error(`writing '${zipFilePath}' got error:${err}`))
+              },
+            )
+            console.log(green(`...export done.`))
+          })
+          .catch((e) => {
+            console.log(error(`export got error:${e}`))
+          })
+      }
+      break
+    default:
+      console.log(error(`unknown export format '${format}'`))
+      break
+  }
+}
+
+function openFbaFile(filePath: string): Promise<Fishbone> {
+  return new Promise((resolve, reject) => {
+    fs.readFile(filePath, 'utf8', (err, fbaFileContent) => {
+      if (err) {
+        reject(err)
+      } else {
+        try {
+          const fba = getFBDataFromText(fbaFileContent)
+          resolve(fba)
+        } catch (e) {
+          reject(e)
+        }
+      }
+    })
+  })
+}
+
+function exportToDltViewer(fba: Fishbone, zipFile: JSZip) {
+  console.log(`exportToDltViewer fba.title='${fba.title}'`)
+  const exportedFilters = iterateFbEffects(fba.fishbone, zipFile, [])
+  if (exportedFilters > 0) {
+    console.log(green(`finished exporting ${exportedFilters} filters to dlt-viewer format`))
+  } else {
+    console.log(warning(`no filters exported to dlt-viewer format`))
+  }
+}
+
+function pathNameFor(title: string, curSet: Set<String>, addToSet: boolean): string {
+  let titleName = filenamify(title, { replacement: '_' })
+
+  // check if titleName is already in curSet:
+  let i = 2
+  while (curSet.has(titleName)) {
+    titleName = filenamify(title, { replacement: '_' }) + '_' + i
+    i++
+  }
+  if (addToSet) {
+    curSet.add(titleName)
+  }
+
+  return titleName
+}
+
+function iterateFbEffects(effects: FBEffect[], zipFile: JSZip, prevPaths: string[]): number {
+  let exportedFilters = 0
+  const effectFolderNamesUsed = new Set<string>()
+  for (const effect of effects) {
+    if (effect !== undefined && typeof effect === 'object') {
+      const pathNameForEffect = pathNameFor(effect.name || 'effect', effectFolderNamesUsed, true)
+      console.log(`effect: '${prevPaths.join('/') + pathNameForEffect}'...`) // , Object.keys(effect).join(', '))
+      if (effect.categories?.length) {
+        const categoryFolderNamesUsed = new Set<string>()
+        for (const category of effect.categories) {
+          if (category !== undefined && typeof category === 'object') {
+            const pathNameForCategory = pathNameFor(category.name || 'category', categoryFolderNamesUsed, true)
+            console.log(`category: '${pathNameForCategory}'...`) // , Object.keys(category).join(', '))
+            const rootCauseFolderNamesUsed = new Set<string>()
+            const rcNumberLen = category.rootCauses.length.toString().length
+            for (const [rcIdx, rc] of category.rootCauses.entries()) {
+              if (rc !== undefined && typeof rc === 'object') {
+                const rcPrefix = (1 + rcIdx).toString().padStart(rcNumberLen, '0') + '_'
+                // console.log(`rootCause: '${rcPrefix}' type:'${rc.type}' element:'${rc.element}'`, Object.keys(rc).join(', '))
+                if (rc.type === 'nested' && Array.isArray(rc.data)) {
+                  const pathNameForRootCause = pathNameFor(
+                    rcPrefix + (rc.title || rc.props?.label || 'rootCause'),
+                    rootCauseFolderNamesUsed,
+                    false,
+                  )
+                  // rootCauseFolderNamesUsed.add(pathNameForRootCause)
+                  iterateFbEffects(rc.data, zipFile, prevPaths.concat([pathNameForEffect, pathNameForCategory, pathNameForRootCause]))
+                } else {
+                  if (rc.type === 'react' && rc.element === 'FBACheckbox' && rc.props !== undefined) {
+                    const pathNameForRootCause = pathNameFor(rc.title || rc.props?.label || 'rootCause', rootCauseFolderNamesUsed, false)
+                    // no need to add as it will always be unique
+                    const checkboxProps = rc.props
+                    // console.log(`checkbox label: '${checkboxProps.label}'`)
+                    // 3 possible filter sources:
+                    // - checkboxProps.filter
+                    // - checkboxProps.badge.source
+                    // - checkboxProps.badge2.source
+                    exportedFilters += exportFilter(
+                      checkboxProps.filter?.source,
+                      zipFile,
+                      prevPaths.concat([pathNameForEffect, pathNameForCategory, rcPrefix + 'apply_' + pathNameForRootCause]),
+                    )
+                    exportedFilters += exportFilter(
+                      checkboxProps.badge?.source,
+                      zipFile,
+                      prevPaths.concat([pathNameForEffect, pathNameForCategory, rcPrefix + 'badge1_' + pathNameForRootCause]),
+                    )
+                    exportedFilters += exportFilter(
+                      checkboxProps.badge2?.source,
+                      zipFile,
+                      prevPaths.concat([pathNameForEffect, pathNameForCategory, rcPrefix + 'badge2_' + pathNameForRootCause]),
+                    )
+                  } else {
+                    console.log(warning(`ignored rootCause type='${rc.type}' element='${rc.element}'`))
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return exportedFilters
+}
+
+function exportFilter(filter: any, zipFile: JSZip, dirs: string[]): number {
+  // some params to ignore:
+  if (filter === undefined || filter === null || filter === '') {
+    return 0
+  }
+  if (typeof filter !== 'string') {
+    console.log(warning(`exported filter: not a string! keys='${Object.keys(filter).join(',')}', filter='${JSON.stringify(filter)}'`))
+  }
+  if (filter.startsWith('ext:mbehr1.dlt-logs/')) {
+    try {
+      let exportedFilters: XMLBuilder[] = []
+      const rq = rqUriDecode(filter)
+      if (rq.path.endsWith('/filters?')) {
+        if (rq.commands.length > 0) {
+          for (const command of rq.commands) {
+            switch (command.cmd) {
+              case 'add': // params = single filterFrag object
+              case 'query': // params = array of filterFrags
+                try {
+                  const params = command.cmd === 'add' ? [JSON5.parse(command.param)] : JSON5.parse(command.param)
+                  if (Array.isArray(params) && params.length > 0 && params.every((e) => typeof e === 'object')) {
+                    let xmlFrags = params.map(exportFilterFrags).flat()
+                    exportedFilters.push(...xmlFrags)
+                  } else {
+                    console.log(warning(`exporting filter: not array or empty! cmd:'${command.cmd}' params:'${params}'`))
+                  }
+                } catch (e) {
+                  console.log(warning(`exporting filter: json parsing: '${command.param} got error: ${e}'`))
+                }
+                break
+              case 'report': // do we need to treat this differently?
+                // params expected to be an array
+                break
+              case 'delete': // can be ignored without warning
+              case 'deleteAll':
+              case 'disableAll':
+              case 'enableAll':
+              case 'patch':
+                break
+              default:
+                console.log(warning(` unknown command=${command.cmd}`))
+            }
+          }
+        }
+      } else {
+        console.log(warning(`exporting filter: ignored rest query '${rq.path}'`))
+      }
+      if (exportedFilters.length > 0) {
+        // console.log(green(`exported ${exportedFilters.length} filter...`))
+        // console.log(green(`exporting filter: xml='${exportedFilters.map((p) => p.toString()).join(',')}'`))
+        let xml = create({ version: '1.0', encoding: 'UTF-8' }).ele('dltfilter')
+        xml.com(`exported by fba-cli v${version()}`)
+        for (const xmlFrag of exportedFilters) {
+          xml.import(xmlFrag)
+        }
+        const xmlFileContent = xml.end({ prettyPrint: true })
+        //console.log(green(`exporting filter: xml='${xmlFileContent.length}'`))
+        zipFile.file(dirs.join('/') + '.xml', xmlFileContent)
+      }
+      return exportedFilters.length
+    } catch (e) {
+      console.log(warning(`exporting filter: '${filter.slice(0, 100)} got error: ${e}'`))
+      return 0
+    }
+  } else {
+    console.log(warning(`ignored filter, not a dlt-logs filter! filter='${filter}'`))
+    return 0
+  }
+}
+
+function exportFilterFrags(filterFrag: any): XMLBuilder[] {
+  // console.log(`exportFilterFrags: '${JSON.stringify(filterFrag)}'`)
+  // attributes to not export: tmpFb, not, lifecycles
+  // special handling for lifecycle neg filter:
+  if (filterFrag.lifecycles !== undefined && filterFrag.not === true && filterFrag.type === 1) {
+    // remove the known/expected keys:
+    const { not: _a, lifecycles: _b, tmpFb: _c, type: _d, name: _e, maxNrMsgs: _f, atLoadTime: _g, ...remObj } = filterFrag
+    if (Object.keys(remObj).length > 0) {
+      console.log(
+        warning(`exporting filter: ignored empty filter! keys='${Object.keys(remObj).join(',')}' filter='${JSON.stringify(remObj)}'`),
+      )
+    }
+    return []
+  }
+  // remove the not to export/to be ignored properties:
+  const { tmpFb: _a, maxNrMsgs: _b, atLoadTime: _c, ...toExport } = filterFrag
+  if (Object.keys(toExport).length === 0) {
+    console.log(warning(`exporting filter: ignored empty filter! filter=${JSON.stringify(filterFrag)}`))
+    return []
+  }
+  console.log(green(`exporting filter with keys: '${Object.keys(toExport).join(',')}'`))
+
+  const fragToRet = fragment().ele('filter')
+  fragToRet.ele({ type: filterFrag.type ?? 0 })
+  fragToRet.ele({ name: filterFrag.name ?? '' }) // todo or use e.g. a name of the rootcause as fallback?
+  fragToRet.ele({ ecuid: filterFrag.ecu ?? '' })
+  fragToRet.ele({ applicationid: filterFrag.apid ?? '' })
+  fragToRet.ele({ contextid: filterFrag.ctid ?? '' })
+  fragToRet.ele({ headertext: '' })
+  fragToRet.ele({ payloadtext: filterFrag.payloadRegex ?? filterFrag.payload ?? '' })
+  fragToRet.ele({ logLevelMax: filterFrag.loglevelMax ?? 0 })
+  fragToRet.ele({ logLevelMin: filterFrag.logLevelMin ?? 0 })
+
+  fragToRet.ele({ enablefilter: 'enabled' in filterFrag ? (filterFrag.enabled ? 1 : 0) : 1 })
+  fragToRet.ele({ enableecuid: 'ecu' in filterFrag ? 1 : 0 })
+  // enableregexp_Ecuid doesn't exist -> export anyhow? ecuIsRegex
+  fragToRet.ele({ enableenableapplicationid: 'apid' in filterFrag ? 1 : 0 })
+  fragToRet.ele({ enableregexp_Appid: 'apidIsRegex' in filterFrag ? (filterFrag.apidIsRegex ? 1 : 0) : 0 })
+  fragToRet.ele({ enablecontextid: 'ctid' in filterFrag ? 1 : 0 })
+  fragToRet.ele({ enableregexp_Context: 'ctidIsRegex' in filterFrag ? (filterFrag.ctidIsRegex ? 1 : 0) : 0 })
+  fragToRet.ele({ enablepayloadtext: 'payloadRegex' in filterFrag || 'payload' in filterFrag ? 1 : 0 })
+  fragToRet.ele({ enableregexp_Payload: filterFrag.payloadRegex ? 1 : 0 })
+  fragToRet.ele({ ignoreCase_Payload: 'ignoreCasePayload' in filterFrag ? (filterFrag.ignoreCasePayload ? 1 : 0) : 0 })
+  fragToRet.ele({ enableLogLevelMax: 'loglevelMax' in filterFrag ? 1 : 0 })
+  fragToRet.ele({ enableLogLevelMin: 'logLevelMin' in filterFrag ? 1 : 0 })
+  fragToRet.ele({
+    enablecontrolmsgs: 'verb_mstp_mtin' in filterFrag ? (((filterFrag.verb_mstp_mtin as number) & 0x03) === 0x03 ? 1 : 0) : 0,
+  }) // todo verb_mstp_mtin (pref) or mstp (todo!)
+  // todo ...  // filter.verb_mstp_mtin = Some((0x03u8 << 1, (7u8 << 1)));
+
+  // todo add filterColour/marker...
+
+  return [fragToRet]
+}

--- a/src/fbaFormat.ts
+++ b/src/fbaFormat.ts
@@ -39,6 +39,7 @@ export interface FBAttribute {
 }
 export interface FBEffect {
   fbUid: string
+  name?: string
   categories: FBCategory[]
 }
 
@@ -47,7 +48,7 @@ export interface FBACheckboxProps {
   value?: any
   instructions?: string | { markdownFormat: boolean; textValue: string }
   backgroundDescription?: string | { markdownFormat: boolean; textValue: string }
-  filter?: any // todo
+  filter?: FBFilter
   badge?: FBBadge
   badge2?: FBBadge
 }
@@ -64,7 +65,15 @@ export interface FBRootCause {
 
 export interface FBCategory {
   fbUid: string
+  name?: string
   rootCauses: FBRootCause[]
+}
+
+// todo verify those entries! (source & jsonPath confirmed)
+export interface FBFilter {
+  source: string // restQuery
+  jsonPath?: string // not needed for apply-filter!
+  conv?: string // not needed for apply-filter, check! length | index:idx | func: fn(result)...
 }
 
 export interface FBBadge {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@
 import { Command } from 'commander'
 import { version } from './util.js'
 import { cmdExec } from './cmdExec.js'
+import { cmdExport } from './cmdExport.js'
 
 try {
   const program = new Command()
@@ -25,6 +26,14 @@ try {
     // .option('-j, --junit <output>', 'junit output filename ')
     .argument('<files...>', 'FBA and DLT files to be processed')
     .action(cmdExec)
+
+  program
+    .command('export')
+    .description('export info from FBA files')
+    .requiredOption('-f, --format <type>', 'format to export: currently only "dlt-viewer" for filters in dlt-viewer xml format')
+    .argument('<fbaFile>', 'FBA file where to export from')
+    .argument('<zipFile>', 'output zip file path. Existing ones will be overwritten!')
+    .action(cmdExport)
 
   program.parse()
   const options = program.opts()


### PR DESCRIPTION
The export creates a zip file with all filters from the full fishbone.

Usage:
fba-cli export -f dlt-viewer <fba file> <output.zip>