### PR TITLE
fix(export): autodetect regex for apid/ctid

### DIFF
--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals'
-import { version } from './util'
+import { version, containsRegexChars } from './util'
 
 describe('getVersion', () => {
   it('should return a version', () => {
@@ -13,5 +13,17 @@ describe('getVersion', () => {
     // even if called twice (as impl caches)
     const v2 = version()
     expect(v2).toMatch(/\d+\.\d+\.\d+/)
+  })
+})
+
+describe('containsRegexChars', () => {
+  it('should return false on regular chars', () => {
+    expect(containsRegexChars('foo')).toBe(false)
+  })
+  it('should return false on e.g. pipe char', () => {
+    expect(containsRegexChars('foo|bar')).toBe(true)
+  })
+  it('should return false on e.g. \\ char', () => {
+    expect(containsRegexChars('foo\\bar')).toBe(true)
   })
 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -47,3 +47,31 @@ export function sleep(ms: number): Promise<void> {
     setTimeout(resolve, ms)
   })
 }
+
+export function containsRegexChars(text: String): boolean {
+  return text.match(/[\^\$\*\+\?\(\)\[\]\{\}\|\.\-\\\=\!\<\>\,]/g) !== null
+  /*
+   s.contains(|c| {
+        c == '^'
+            || c == '$'
+            || c == '*'
+            || c == '+'
+            || c == '?'
+            || c == '('
+            || c == ')'
+            || c == '['
+            || c == ']'
+            || c == '{'
+            || c == '}'
+            || c == '|'
+            || c == '.'
+            || c == '-'
+            || c == '\\'
+            || c == '='
+            || c == '!'
+            || c == '<'
+            || c == '>'
+            || c == ','
+    })
+  */
+}


### PR DESCRIPTION
and ignore empty length for apid, ctid, payload.