### PR TITLE
ci: semantic-release dont include release-notes-generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
       },
       "devDependencies": {
         "@semantic-release/git": "^10.0.1",
-        "@semantic-release/release-notes-generator": "^14.0.1",
         "@types/cli-progress": "^3.11.6",
         "@types/jest": "^29.5.13",
         "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
   },
   "devDependencies": {
     "@semantic-release/git": "^10.0.1",
-    "@semantic-release/release-notes-generator": "^14.0.1",
     "@types/cli-progress": "^3.11.6",
     "@types/jest": "^29.5.13",
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
as its already a dependency of semantic-release.