### PR TITLE
feat(exec): add option to write report to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ npm.cmd run fba-cli exec -p 127.0.0.1:7777 -c config.json analysis.fba recorded.
 node dist\index.js exec -p 127.0.0.1:7777 -c config.json analysis.fba recorded.dlt > analysis_report.md
 ```
 
+alternatively you can use the `-o` option to write the output file directly:
+
+```powershell
+
+# fba-cli exec -p host:port -c <config_file> -o <output_file> <list of fba files> <list of DLT files>
+# e.g.
+npm.cmd run fba-cli exec -p 127.0.0.1:7777 -c config.json -o analysis_report.md analysis.fba recorded.dlt recorded_p2.dlt
+# seems that powershell doesnt allow the binary/scripts to be directly executed. In that case you can start via:
+node dist\index.js exec -p 127.0.0.1:7777 -c config.json -o analysis_report.md analysis.fba recorded.dlt
+```
+
 ### Export filters in DLT-Viewer format:
 
 ```bash

--- a/src/cmdExec.ts
+++ b/src/cmdExec.ts
@@ -321,7 +321,21 @@ export const cmdExec = async (files: string[], options: any) => {
             const reportAsMd = fbReportToMdast(report)
             try {
               mdassert(reportAsMd)
-              console.log(toMarkdown(reportAsMd, { extensions: [gfmTableToMarkdown({ tablePipeAlign: false })] }))
+              const reportAsMdText = toMarkdown(reportAsMd, { extensions: [gfmTableToMarkdown({ tablePipeAlign: false })] })
+              if (!options.output) {
+                console.log(reportAsMdText)
+              }else{
+                try{
+                  // write an UTF8 BOM so that editors can easier detect the encoding:
+                  fs.writeFileSync(options.output, '\ufeff')
+                  fs.writeFileSync(options.output, reportAsMdText)
+                  multibar.log(`Report written to '${options.output}'\n`)
+                }catch(e){
+                  multibar.log(`Failed to write report to '${options.output}'! Got error:${e}\n`)
+                  console.log(error(`Failed to write report to '${options.output}'! Got error:${e}`))
+                }
+                multibar.update()
+              }
             } catch (e) {
               console.log(inspect(reportAsMd))
               console.warn(`reportAsMd got error:${e}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ try {
   program // todo or move to cmdExec?
     .command('exec')
     .description('execute FBA files with DLT-logs')
+    .option('-o, --output <filename>', 'output file name (default is output to console)')
     .option('-c, --config <config>', 'json config file with object key dlt-logs.plugins')
     .option('-p, --port <port>', 'adlt remote host:port e.g. 127.0.0.1:7777. Otherwise an adlt if in path will be started locally.')
     .option('--no_events', "don't process events")


### PR DESCRIPTION
Added -o --output <filename> option to write the report directly to a file.
The file will be UTF8 encoded and a BOM is added
to ease detection for editors.